### PR TITLE
bugfix#155-update_tree_table_modal_width_and_th_colors

### DIFF
--- a/app/assets/stylesheets/nu_avalon/components/_tree-table.scss
+++ b/app/assets/stylesheets/nu_avalon/components/_tree-table.scss
@@ -1,0 +1,14 @@
+// At least one place these styles are located
+// is in a modal window, importing files from Dropbox/s3
+table.treetable {
+  thead {
+    background: $nu-purple;
+    color: $white;
+    tr {
+      th {
+        border: none;
+        padding: .5rem .75rem;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/nu_avalon/main.scss
+++ b/app/assets/stylesheets/nu_avalon/main.scss
@@ -26,7 +26,8 @@
   'components/mediaelement',
   'components/pagination',
   'components/playlists',
-  'components/tabs';
+  'components/tabs',
+  'components/tree-table';
 
 // 6. Page-specific styles
 @import

--- a/app/assets/stylesheets/nu_avalon/pages/_manage-files.scss
+++ b/app/assets/stylesheets/nu_avalon/pages/_manage-files.scss
@@ -40,3 +40,11 @@
   position: relative;
   z-index: 1;
 }
+
+
+// Importing files from amazon s3 or dropbox
+#browse-everything {
+  .modal-dialog {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
This is designed to fix the file title issue in #155 .  It updates the modal window width, and also updates the table header elements to NU branding. 

NOTE: I can't verify this locally as the Dropbox modal window errors out, but pretty sure this fix should apply and won't break anything.