### PR TITLE
Treeify the MasterFile target filename instead of just prefixing it

### DIFF
--- a/config/initializers/master_file_move_filename.rb
+++ b/config/initializers/master_file_move_filename.rb
@@ -1,0 +1,12 @@
+require File.join(Rails.root, 'app/models/master_file')
+
+class MasterFile
+  def self.post_processing_move_filename(oldpath, options = {})
+    prefix = ActiveFedora::Noid.treeify(options[:id].tr(':', '_'))
+    if File.basename(oldpath).start_with?(prefix)
+      File.basename(oldpath)
+    else
+      "#{prefix}/#{File.basename(oldpath)}"
+    end
+  end
+end


### PR DESCRIPTION
Move master files to target bucket with a pair tree prefix instead of just `"#{masterfile.id}-#{filename}"`