### PR TITLE
Add a loading indicator to media player for Chrome rendering delay

### DIFF
--- a/app/assets/javascripts/nu-avalon/script.js
+++ b/app/assets/javascripts/nu-avalon/script.js
@@ -13,10 +13,57 @@ function checkAlerts() {
   }
 }
 
+// Remove a node, after slight delay
 function removeNode(el) {
   setTimeout(function () {
     el.parentNode.removeChild(el);
   }, 500);
 }
 
+function removeLoader() {
+  console.log('removeLoader');
+  var loader = document.getElementsByClassName('loader');
+  if (loader.length > 0) {
+    loader[0].parentNode.removeChild(loader[0]);
+  }
+}
+
+function getAvalonPlayer() {
+  var el = document.getElementsByClassName('avalon-player');
+  if (el.length > 0) {
+    addLoader(el);
+  }
+}
+
+function addLoader(el) {
+  var loaderEl = document.createElement('div');
+  loaderEl.className = 'loader';
+  el[0].appendChild(loaderEl);
+  addPoller(15);
+}
+
+function addPoller(counter) {
+  if (counter > 0) {
+    var totalTimeEl = document.getElementsByClassName('mejs-duration');
+    if (totalTimeEl.length > 0) {
+      // Is it all Os or valid time?
+      if (totalTimeEl.innerText === '00:00') {
+        rePoll(counter);
+      } else {
+        removeLoader();
+      }
+    } else {
+      rePoll(counter);
+    }
+  }
+}
+
+function rePoll(counter) {
+  setTimeout(function() {
+    addPoller(counter - 1);
+  }, 1000);
+}
+
+
 checkAlerts();
+getAvalonPlayer();

--- a/app/assets/stylesheets/nu_avalon/components/_loader.scss
+++ b/app/assets/stylesheets/nu_avalon/components/_loader.scss
@@ -1,0 +1,76 @@
+.loader {
+  margin: 100px auto;
+  font-size: 25px;
+  width: 1em;
+  height: 1em;
+  border-radius: 50%;
+  position: relative;
+  text-indent: -9999em;
+  -webkit-animation: load5 1.1s infinite ease;
+  animation: load5 1.1s infinite ease;
+  -webkit-transform: translateZ(0);
+  -ms-transform: translateZ(0);
+  transform: translateZ(0);
+
+  // Custom styles
+  margin: auto;
+  position: absolute;
+  z-index: 10;
+  top: 195px;
+  left: 0;
+  right: 0;
+}
+@-webkit-keyframes load5 {
+  0%,
+  100% {
+    box-shadow: 0em -2.6em 0em 0em #fafffc, 1.8em -1.8em 0 0em rgba(250,255,252, 0.2), 2.5em 0em 0 0em rgba(250,255,252, 0.2), 1.75em 1.75em 0 0em rgba(250,255,252, 0.2), 0em 2.5em 0 0em rgba(250,255,252, 0.2), -1.8em 1.8em 0 0em rgba(250,255,252, 0.2), -2.6em 0em 0 0em rgba(250,255,252, 0.5), -1.8em -1.8em 0 0em rgba(250,255,252, 0.7);
+  }
+  12.5% {
+    box-shadow: 0em -2.6em 0em 0em rgba(250,255,252, 0.7), 1.8em -1.8em 0 0em #fafffc, 2.5em 0em 0 0em rgba(250,255,252, 0.2), 1.75em 1.75em 0 0em rgba(250,255,252, 0.2), 0em 2.5em 0 0em rgba(250,255,252, 0.2), -1.8em 1.8em 0 0em rgba(250,255,252, 0.2), -2.6em 0em 0 0em rgba(250,255,252, 0.2), -1.8em -1.8em 0 0em rgba(250,255,252, 0.5);
+  }
+  25% {
+    box-shadow: 0em -2.6em 0em 0em rgba(250,255,252, 0.5), 1.8em -1.8em 0 0em rgba(250,255,252, 0.7), 2.5em 0em 0 0em #fafffc, 1.75em 1.75em 0 0em rgba(250,255,252, 0.2), 0em 2.5em 0 0em rgba(250,255,252, 0.2), -1.8em 1.8em 0 0em rgba(250,255,252, 0.2), -2.6em 0em 0 0em rgba(250,255,252, 0.2), -1.8em -1.8em 0 0em rgba(250,255,252, 0.2);
+  }
+  37.5% {
+    box-shadow: 0em -2.6em 0em 0em rgba(250,255,252, 0.2), 1.8em -1.8em 0 0em rgba(250,255,252, 0.5), 2.5em 0em 0 0em rgba(250,255,252, 0.7), 1.75em 1.75em 0 0em #fafffc, 0em 2.5em 0 0em rgba(250,255,252, 0.2), -1.8em 1.8em 0 0em rgba(250,255,252, 0.2), -2.6em 0em 0 0em rgba(250,255,252, 0.2), -1.8em -1.8em 0 0em rgba(250,255,252, 0.2);
+  }
+  50% {
+    box-shadow: 0em -2.6em 0em 0em rgba(250,255,252, 0.2), 1.8em -1.8em 0 0em rgba(250,255,252, 0.2), 2.5em 0em 0 0em rgba(250,255,252, 0.5), 1.75em 1.75em 0 0em rgba(250,255,252, 0.7), 0em 2.5em 0 0em #fafffc, -1.8em 1.8em 0 0em rgba(250,255,252, 0.2), -2.6em 0em 0 0em rgba(250,255,252, 0.2), -1.8em -1.8em 0 0em rgba(250,255,252, 0.2);
+  }
+  62.5% {
+    box-shadow: 0em -2.6em 0em 0em rgba(250,255,252, 0.2), 1.8em -1.8em 0 0em rgba(250,255,252, 0.2), 2.5em 0em 0 0em rgba(250,255,252, 0.2), 1.75em 1.75em 0 0em rgba(250,255,252, 0.5), 0em 2.5em 0 0em rgba(250,255,252, 0.7), -1.8em 1.8em 0 0em #fafffc, -2.6em 0em 0 0em rgba(250,255,252, 0.2), -1.8em -1.8em 0 0em rgba(250,255,252, 0.2);
+  }
+  75% {
+    box-shadow: 0em -2.6em 0em 0em rgba(250,255,252, 0.2), 1.8em -1.8em 0 0em rgba(250,255,252, 0.2), 2.5em 0em 0 0em rgba(250,255,252, 0.2), 1.75em 1.75em 0 0em rgba(250,255,252, 0.2), 0em 2.5em 0 0em rgba(250,255,252, 0.5), -1.8em 1.8em 0 0em rgba(250,255,252, 0.7), -2.6em 0em 0 0em #fafffc, -1.8em -1.8em 0 0em rgba(250,255,252, 0.2);
+  }
+  87.5% {
+    box-shadow: 0em -2.6em 0em 0em rgba(250,255,252, 0.2), 1.8em -1.8em 0 0em rgba(250,255,252, 0.2), 2.5em 0em 0 0em rgba(250,255,252, 0.2), 1.75em 1.75em 0 0em rgba(250,255,252, 0.2), 0em 2.5em 0 0em rgba(250,255,252, 0.2), -1.8em 1.8em 0 0em rgba(250,255,252, 0.5), -2.6em 0em 0 0em rgba(250,255,252, 0.7), -1.8em -1.8em 0 0em #fafffc;
+  }
+}
+@keyframes load5 {
+  0%,
+  100% {
+    box-shadow: 0em -2.6em 0em 0em #fafffc, 1.8em -1.8em 0 0em rgba(250,255,252, 0.2), 2.5em 0em 0 0em rgba(250,255,252, 0.2), 1.75em 1.75em 0 0em rgba(250,255,252, 0.2), 0em 2.5em 0 0em rgba(250,255,252, 0.2), -1.8em 1.8em 0 0em rgba(250,255,252, 0.2), -2.6em 0em 0 0em rgba(250,255,252, 0.5), -1.8em -1.8em 0 0em rgba(250,255,252, 0.7);
+  }
+  12.5% {
+    box-shadow: 0em -2.6em 0em 0em rgba(250,255,252, 0.7), 1.8em -1.8em 0 0em #fafffc, 2.5em 0em 0 0em rgba(250,255,252, 0.2), 1.75em 1.75em 0 0em rgba(250,255,252, 0.2), 0em 2.5em 0 0em rgba(250,255,252, 0.2), -1.8em 1.8em 0 0em rgba(250,255,252, 0.2), -2.6em 0em 0 0em rgba(250,255,252, 0.2), -1.8em -1.8em 0 0em rgba(250,255,252, 0.5);
+  }
+  25% {
+    box-shadow: 0em -2.6em 0em 0em rgba(250,255,252, 0.5), 1.8em -1.8em 0 0em rgba(250,255,252, 0.7), 2.5em 0em 0 0em #fafffc, 1.75em 1.75em 0 0em rgba(250,255,252, 0.2), 0em 2.5em 0 0em rgba(250,255,252, 0.2), -1.8em 1.8em 0 0em rgba(250,255,252, 0.2), -2.6em 0em 0 0em rgba(250,255,252, 0.2), -1.8em -1.8em 0 0em rgba(250,255,252, 0.2);
+  }
+  37.5% {
+    box-shadow: 0em -2.6em 0em 0em rgba(250,255,252, 0.2), 1.8em -1.8em 0 0em rgba(250,255,252, 0.5), 2.5em 0em 0 0em rgba(250,255,252, 0.7), 1.75em 1.75em 0 0em #fafffc, 0em 2.5em 0 0em rgba(250,255,252, 0.2), -1.8em 1.8em 0 0em rgba(250,255,252, 0.2), -2.6em 0em 0 0em rgba(250,255,252, 0.2), -1.8em -1.8em 0 0em rgba(250,255,252, 0.2);
+  }
+  50% {
+    box-shadow: 0em -2.6em 0em 0em rgba(250,255,252, 0.2), 1.8em -1.8em 0 0em rgba(250,255,252, 0.2), 2.5em 0em 0 0em rgba(250,255,252, 0.5), 1.75em 1.75em 0 0em rgba(250,255,252, 0.7), 0em 2.5em 0 0em #fafffc, -1.8em 1.8em 0 0em rgba(250,255,252, 0.2), -2.6em 0em 0 0em rgba(250,255,252, 0.2), -1.8em -1.8em 0 0em rgba(250,255,252, 0.2);
+  }
+  62.5% {
+    box-shadow: 0em -2.6em 0em 0em rgba(250,255,252, 0.2), 1.8em -1.8em 0 0em rgba(250,255,252, 0.2), 2.5em 0em 0 0em rgba(250,255,252, 0.2), 1.75em 1.75em 0 0em rgba(250,255,252, 0.5), 0em 2.5em 0 0em rgba(250,255,252, 0.7), -1.8em 1.8em 0 0em #fafffc, -2.6em 0em 0 0em rgba(250,255,252, 0.2), -1.8em -1.8em 0 0em rgba(250,255,252, 0.2);
+  }
+  75% {
+    box-shadow: 0em -2.6em 0em 0em rgba(250,255,252, 0.2), 1.8em -1.8em 0 0em rgba(250,255,252, 0.2), 2.5em 0em 0 0em rgba(250,255,252, 0.2), 1.75em 1.75em 0 0em rgba(250,255,252, 0.2), 0em 2.5em 0 0em rgba(250,255,252, 0.5), -1.8em 1.8em 0 0em rgba(250,255,252, 0.7), -2.6em 0em 0 0em #fafffc, -1.8em -1.8em 0 0em rgba(250,255,252, 0.2);
+  }
+  87.5% {
+    box-shadow: 0em -2.6em 0em 0em rgba(250,255,252, 0.2), 1.8em -1.8em 0 0em rgba(250,255,252, 0.2), 2.5em 0em 0 0em rgba(250,255,252, 0.2), 1.75em 1.75em 0 0em rgba(250,255,252, 0.2), 0em 2.5em 0 0em rgba(250,255,252, 0.2), -1.8em 1.8em 0 0em rgba(250,255,252, 0.5), -2.6em 0em 0 0em rgba(250,255,252, 0.7), -1.8em -1.8em 0 0em #fafffc;
+  }
+}

--- a/app/assets/stylesheets/nu_avalon/main.scss
+++ b/app/assets/stylesheets/nu_avalon/main.scss
@@ -24,6 +24,7 @@
   'components/buttons',
   'components/dropdown-toggle',
   'components/facets',
+  'components/loader',
   'components/mediaelement',
   'components/pagination',
   'components/playlists',


### PR DESCRIPTION
In a nutshell, this checks if a mediaelement player is on a page, and if so overlays a loading indicator over the player.

Then a custom poller kicks in, and checks for a total time duration update on the page itself, as a roundabout way to determine whether the video is ready to play or not.   The poller will check 15 times, in 1 second intervals, then die after it removes the spinner, or just dies after 15 attempts.  This accounts for a 15 second delay more or less.