### PR TITLE
Add loader bar for audio; add insurance cleanup

### DIFF
--- a/app/assets/javascripts/nu-avalon/script.js
+++ b/app/assets/javascripts/nu-avalon/script.js
@@ -1,44 +1,15 @@
-// Find any alerts on page
-function checkAlerts() {
-  var alertElements = document.getElementsByClassName('alert-success'),
-    el;
-
-  if (alertElements.length > 0) {
-    el = alertElements[0];
-    // Fade out
-    setTimeout(function () {
-      el.style.opacity = '0';
-      removeNode(el);
-    }, 5000);
-  }
-}
-
-// Remove a node, after slight delay
-function removeNode(el) {
-  setTimeout(function () {
-    el.parentNode.removeChild(el);
-  }, 500);
-}
-
-function removeLoader() {
-  var loader = document.getElementsByClassName('loader');
-  if (loader.length > 0) {
-    loader[0].parentNode.removeChild(loader[0]);
-  }
-}
-
-function getAvalonPlayer() {
-  var el = document.getElementsByClassName('avalon-player');
-  if (el.length > 0) {
-    addLoader(el);
-  }
-}
-
 function addLoader(el) {
-  var loaderEl = document.createElement('div');
-  loaderEl.className = 'loader';
+  var loaderEl = document.createElement('div'),
+    playerType = getPlayerType(el);
+
+  loaderEl.className = (playerType === 'audio') ? 'loader-bar' : 'loader';
+
+  // Add a faded-out class to the player behind the loader
+  el[0].classList.add('loader-opacity');
+
   el[0].appendChild(loaderEl);
   addPoller(15);
+  insuranceCleanup(20000);
 }
 
 function addPoller(counter) {
@@ -61,12 +32,62 @@ function addPoller(counter) {
   }
 }
 
+// Find any alerts on page
+function checkAlerts() {
+  var alertElements = document.getElementsByClassName('alert-success'),
+    el;
+
+  if (alertElements.length > 0) {
+    el = alertElements[0];
+    // Fade out
+    setTimeout(function () {
+      el.style.opacity = '0';
+      removeNode(el);
+    }, 5000);
+  }
+}
+
+function getAvalonPlayer() {
+  var el = document.getElementsByClassName('avalon-player');
+  if (el.length > 0) {
+    addLoader(el);
+  }
+}
+
+function getPlayerType(el) {
+  var playerType = (el[0].getElementsByTagName('audio').length > 0) ? 'audio' : 'video';
+  return playerType;
+}
+
+// Insurance loader removal after 20 seconds
+function insuranceCleanup(milliseconds) {
+  setTimeout(function() {
+    removeLoader();
+  }, milliseconds);
+}
+
 function rePoll(counter) {
   setTimeout(function() {
     addPoller(counter - 1);
   }, 1000);
 }
 
+// Remove a node, after slight delay
+function removeNode(el) {
+  setTimeout(function () {
+    el.parentNode.removeChild(el);
+  }, 500);
+}
+
+function removeLoader() {
+  var loader = document.querySelectorAll('.loader, .loader-bar'),
+    parentNode = null;
+  if (loader.length > 0) {
+    parentNode = loader[0].parentNode;
+    parentNode.classList.remove('loader-opacity');
+    parentNode.removeChild(loader[0]);
+  }
+}
 
 checkAlerts();
 getAvalonPlayer();

--- a/app/assets/stylesheets/nu_avalon/components/_loader.scss
+++ b/app/assets/stylesheets/nu_avalon/components/_loader.scss
@@ -1,10 +1,9 @@
+// Circular CSS loader
 .loader {
-  margin: 100px auto;
   font-size: 25px;
   width: 1em;
   height: 1em;
   border-radius: 50%;
-  position: relative;
   text-indent: -9999em;
   -webkit-animation: load5 1.1s infinite ease;
   animation: load5 1.1s infinite ease;
@@ -20,6 +19,84 @@
   left: 0;
   right: 0;
 }
+// Horizontal CSS loader bar
+.loader-bar,
+.loader-bar:before,
+.loader-bar:after {
+  background: #ffffff;
+  -webkit-animation: load1 1s infinite ease-in-out;
+  animation: load1 1s infinite ease-in-out;
+  width: 1em;
+  height: 4em;
+}
+.loader-bar {
+  color: #ffffff;
+  text-indent: -9999em;
+  margin: auto;
+  position: absolute;
+  font-size: 7px;
+  -webkit-transform: translateZ(0);
+  -ms-transform: translateZ(0);
+  transform: translateZ(0);
+  -webkit-animation-delay: -0.16s;
+  animation-delay: -0.16s;
+  top: 12px;
+  left: 0;
+  right: 0;
+}
+.loader-bar:before,
+.loader-bar:after {
+  position: absolute;
+  top: 0;
+  content: '';
+}
+.loader-bar:before {
+  left: -1.5em;
+  -webkit-animation-delay: -0.32s;
+  animation-delay: -0.32s;
+}
+.loader-bar:after {
+  left: 1.5em;
+}
+
+// Fade out the element behind loader to drive home the point it's not ready
+.loader-opacity {
+  opacity: .5;
+}
+
+// Mobile
+@media screen and (max-width: 550px) {
+  .loader {
+    top: 90px;
+  }
+}
+
+@-webkit-keyframes load1 {
+  0%,
+  80%,
+  100% {
+    box-shadow: 0 0;
+    height: 4em;
+  }
+  40% {
+    box-shadow: 0 -2em;
+    height: 5em;
+  }
+}
+@keyframes load1 {
+  0%,
+  80%,
+  100% {
+    box-shadow: 0 0;
+    height: 4em;
+  }
+  40% {
+    box-shadow: 0 -2em;
+    height: 5em;
+  }
+}
+
+
 @-webkit-keyframes load5 {
   0%,
   100% {


### PR DESCRIPTION
This adds a loader bar for audio mediaelement players, and also runs a cleanup after 20 seconds just in case something squirly happens and the loader is still going.