### PR TITLE
Increase nginx proxy_read_timeout to 70 minutes 

### DIFF
--- a/.ebextensions/05_nginx_worker_timeout.config
+++ b/.ebextensions/05_nginx_worker_timeout.config
@@ -1,4 +1,4 @@
 commands:
   set_worker_timeout:
-    command: 'sed -i "/match the name of upstream directive which is defined above/a\    proxy_read_timeout 20m;" /etc/nginx/conf.d/webapp_healthd.conf && service nginx restart'
-    test: '[ -n "$SETTINGS__WORKER" ]'
+    command: 'sed -i "/match the name of upstream directive which is defined above/a\    proxy_read_timeout 60m;" /etc/nginx/conf.d/webapp_healthd.conf && service nginx restart'
+    test: 'source $(/opt/elasticbeanstalk/bin/get-config container -k support_dir)/envvars && [ -n "$SETTINGS__WORKER" ]'


### PR DESCRIPTION
in preparation for a more flexible queue visibility timeout