### PR TITLE
Add agentless SSO using omniauth-nusso strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ config/environments/*.local.yml
 config/blacklight.yml
 config/solr.yml
 config/fedora.yml
+config/ssl

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 # Core rails
 gem 'rails', '~> 4.2.11'
 gem 'sqlite3'
+gem 'puma', '~> 4.1'
 
 # Assets
 gem 'coffee-rails', '~> 4.1.0'
@@ -133,7 +134,6 @@ end
 group :production do
   gem 'google-analytics-rails', '1.1.0'
   gem 'lograge'
-  gem 'puma'
 end
 
 # Install the bundle --with aws when running on Amazon Elastic Beanstalk

--- a/Gemfile.local
+++ b/Gemfile.local
@@ -1,3 +1,3 @@
 gem 'ezid-client'
 gem 'honeybadger', '~> 4.0'
-gem 'omniauth-nusso', '>= 0.1.1'
+gem 'omniauth-nusso', '>= 0.1.2'

--- a/Gemfile.local
+++ b/Gemfile.local
@@ -1,3 +1,3 @@
 gem 'ezid-client'
 gem 'honeybadger', '~> 4.0'
-gem 'omniauth-openam'
+gem 'omniauth-nusso', '>= 0.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1154,6 +1154,7 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (5.0.1)
     netrc (0.11.0)
+    nio4r (2.5.2)
     noid (0.9.0)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
@@ -1179,9 +1180,9 @@ GEM
     omniauth-identity (1.1.1)
       bcrypt-ruby (~> 3.0)
       omniauth (~> 1.0)
-    omniauth-openam (1.1.0)
+    omniauth-nusso (0.1.1)
       faraday
-      omniauth (~> 1.0)
+      omniauth
     orm_adapter (0.5.0)
     os (0.9.6)
     parallel (1.12.1)
@@ -1202,7 +1203,8 @@ GEM
     pry-rails (0.3.6)
       pry (>= 0.10.4)
     public_suffix (3.1.1)
-    puma (3.11.4)
+    puma (4.3.3)
+      nio4r (~> 2.0)
     raabro (1.1.5)
     rack (1.6.11)
     rack-protection (1.5.5)
@@ -1548,13 +1550,13 @@ DEPENDENCIES
   net-ldap
   omniauth-identity
   omniauth-lti!
-  omniauth-openam
+  omniauth-nusso (>= 0.1.1)
   parallel
   pg (~> 0.21)
   poltergeist
   pry-byebug
   pry-rails
-  puma
+  puma (~> 4.1)
   rails (~> 4.2.11)
   rb-readline
   rdf (~> 2.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1180,7 +1180,7 @@ GEM
     omniauth-identity (1.1.1)
       bcrypt-ruby (~> 3.0)
       omniauth (~> 1.0)
-    omniauth-nusso (0.1.1)
+    omniauth-nusso (0.1.2)
       faraday
       omniauth
     orm_adapter (0.5.0)
@@ -1550,7 +1550,7 @@ DEPENDENCIES
   net-ldap
   omniauth-identity
   omniauth-lti!
-  omniauth-nusso (>= 0.1.1)
+  omniauth-nusso (>= 0.1.2)
   parallel
   pg (~> 0.21)
   poltergeist

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,56 @@
+# Puma can serve each request in a thread from an internal thread pool.
+# The `threads` method setting takes two numbers: a minimum and maximum.
+# Any libraries that use thread pools should be configured to match
+# the maximum value specified for Puma. Default is set to 5 threads for minimum
+# and maximum; this matches the default thread size of Active Record.
+#
+threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }
+threads threads_count, threads_count
+
+# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
+#
+port        ENV.fetch('PORT') { 3000 }
+
+# Specifies the `environment` that Puma will run in.
+#
+environment ENV.fetch('RAILS_ENV') { 'development' }
+
+# Specifies the number of `workers` to boot in clustered mode.
+# Workers are forked webserver processes. If using threads and workers together
+# the concurrency of the application would be max `threads` * `workers`.
+# Workers do not work on JRuby or Windows (both of which do not support
+# processes).
+#
+# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+
+# Use the `preload_app!` method when specifying a `workers` number.
+# This directive tells Puma to first boot the application and load code
+# before forking the application. This takes advantage of Copy On Write
+# process behavior so workers use less memory. If you use this option
+# you need to make sure to reconnect any threads in the `on_worker_boot`
+# block.
+#
+# preload_app!
+
+# If you are preloading your application and using Active Record, it's
+# recommended that you close any connections to the database before workers
+# are forked to prevent connection leakage.
+#
+# before_fork do
+#   ActiveRecord::Base.connection_pool.disconnect! if defined?(ActiveRecord)
+# end
+
+# The code in the `on_worker_boot` will be called if you are using
+# clustered mode by specifying a number of `workers`. After each worker
+# process is booted, this block will be run. If you are using the `preload_app!`
+# option, you will want to use this block to reconnect to any threads
+# or connections that may have been created at application boot, as Ruby
+# cannot share connections between processes.
+#
+# on_worker_boot do
+#   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
+# end
+#
+
+# Allow puma to be restarted by `rails restart` command.
+plugin :tmp_restart

--- a/config/puma/development.rb
+++ b/config/puma/development.rb
@@ -1,0 +1,1 @@
+bind 'ssl://127.0.0.1:3000?key=config/ssl/devbox.library.key.pem&cert=config/ssl/devbox.library.full.pem'

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,16 +1,40 @@
+---
 active_job:
   queue_adapter: inline
 localstack: {}
 matterhorn:
-  root: 'http://localhost:8081/'
-  baseApplication: 'avalon'
-  cleanup_log: 'log/cleanup_jobs.log'
+  root: http://matterhorn:8080/
+  baseApplication: avalon
+  cleanup_log: log/cleanup_jobs.log
+  media_path: "/masterfiles"
 redis:
   port: 6380
 streaming:
-  server: :generic
-  stream_token_ttl: 20 #minutes
-  content_path: '/srv/avalon/content'
-  rtmp_base: 'rtmp://localhost:1936/avalon'
-  http_base: 'http://localhost:8881/avalon'
-  default_quality: 'low'
+  server: :nginx
+  stream_token_ttl: 20
+  content_path: "/streamfiles"
+  rtmp_base: rtmp://streaming/avalon
+  http_base: http://streaming:8880/avalon
+  default_quality: low
+canvas:
+  api:
+    endpoint: https://canvas.northwestern.edu/
+    token: 1876~PZr1SOiOLjwkdDinwloqkYg7den7CEr06zpTraqIwiFOH1mFp7MfBYRKYcTN4k8S
+domain:
+  host: devbox.library.northwestern.edu
+  port: 3000
+  protocol: http
+dropbox:
+  path: "/masterfiles/dropbox"
+  upload_uri: file:///masterfiles/dropbox
+auth:
+  configuration:
+    nu:
+      name: Northwestern WebSSO
+      params:
+        auth_url: https://websso.it.northwestern.edu/amserver
+        cookie_name: openAMssoToken
+      provider: openam
+solrcloud: true
+zookeeper:
+  connection_str: localhost:9983/configs

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -16,6 +16,10 @@ streaming:
   rtmp_base: rtmp://streaming/avalon
   http_base: http://streaming:8880/avalon
   default_quality: low
+canvas:
+  api:
+    endpoint: https://canvas.northwestern.edu/
+    token: 1876~PZr1SOiOLjwkdDinwloqkYg7den7CEr06zpTraqIwiFOH1mFp7MfBYRKYcTN4k8S
 domain:
   host: devbox.library.northwestern.edu
   port: 3000

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -16,25 +16,13 @@ streaming:
   rtmp_base: rtmp://streaming/avalon
   http_base: http://streaming:8880/avalon
   default_quality: low
-canvas:
-  api:
-    endpoint: https://canvas.northwestern.edu/
-    token: 1876~PZr1SOiOLjwkdDinwloqkYg7den7CEr06zpTraqIwiFOH1mFp7MfBYRKYcTN4k8S
 domain:
   host: devbox.library.northwestern.edu
   port: 3000
-  protocol: http
+  protocol: https
 dropbox:
   path: "/masterfiles/dropbox"
   upload_uri: file:///masterfiles/dropbox
-auth:
-  configuration:
-    nu:
-      name: Northwestern WebSSO
-      params:
-        auth_url: https://websso.it.northwestern.edu/amserver
-        cookie_name: openAMssoToken
-      provider: openam
 solrcloud: true
 zookeeper:
   connection_str: localhost:9983/configs


### PR DESCRIPTION
- Adds [`omniauth-nusso`](https://github.com/nulib/omniauth-nusso) along with updated routes and callbacks_controller
- Removes `omniauth-openam`
- Updates README for `config/ssl` instructions to run SSL locally
- Upgrade puma to `4.3.3`, includes `config/puma/development.rb` configuration to run SSL locally
