### PR TITLE
Update omniauth-nusso to v0.1.3

### DIFF
--- a/Gemfile.local
+++ b/Gemfile.local
@@ -1,3 +1,3 @@
 gem 'ezid-client'
 gem 'honeybadger', '~> 4.0'
-gem 'omniauth-nusso', '>= 0.1.2'
+gem 'omniauth-nusso', '>= 0.1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1180,7 +1180,7 @@ GEM
     omniauth-identity (1.1.1)
       bcrypt-ruby (~> 3.0)
       omniauth (~> 1.0)
-    omniauth-nusso (0.1.2)
+    omniauth-nusso (0.1.3)
       faraday
       omniauth
     orm_adapter (0.5.0)
@@ -1550,7 +1550,7 @@ DEPENDENCIES
   net-ldap
   omniauth-identity
   omniauth-lti!
-  omniauth-nusso (>= 0.1.2)
+  omniauth-nusso (>= 0.1.3)
   parallel
   pg (~> 0.21)
   poltergeist


### PR DESCRIPTION
Updating omniauth-nusso to 0.1.3 will prevent JSON parsing errors from directory search responses. See nulib/omniauth-nusso#1 for more information.