### PR TITLE
Serialize Terms of Use as text, not as array of text.

### DIFF
--- a/app/models/mods_templates.rb
+++ b/app/models/mods_templates.rb
@@ -138,7 +138,7 @@ module ModsTemplates
 
       define_template :_terms_of_use do |xml, text|
         xml.accessCondition(:type => 'use and reproduction'){
-          xml.text(text)
+          xml.text(Array(text).join('; '))
         }
       end
 

--- a/spec/lib/avalon/batch/entry_spec.rb
+++ b/spec/lib/avalon/batch/entry_spec.rb
@@ -163,6 +163,13 @@ describe Avalon::Batch::Entry do
     end
   end
 
+  describe 'terms of use' do
+    let(:entry_fields) {{ title: Faker::Lorem.sentence, date_issued: "#{Time.now}", terms_of_use: ["This is the Terms of Use"] }}
+    it 'sets terms of use' do
+      expect(entry.media_object.descMetadata.to_xml).to include('<accessCondition type="use and reproduction">This is the Terms of Use</accessCondition>')
+    end
+  end
+
   describe '#process!' do
     let(:entry_files) { [{ file: File.join(testdir, filename), offset: '00:00:00.500', label: 'Quis quo', date_digitized: '2015-10-30', skip_transcoding: false }] }
     let(:master_file) { entry.media_object.master_files.first }


### PR DESCRIPTION
Fixes #403 