### PR TITLE
Avoid double-encoding of URIs with spaces in the security service

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,28 +140,3 @@ jobs:
           DEPLOY_ENV: ${{ env.DEPLOY_ENV }}
           HONEYBADGER_API_KEY: ${{ secrets.HONEYBADGER_API_KEY }}
           HONEYBADGER_REVISION: ${{ github.sha }}
-  tflint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        name: Checkout source code
-
-      - uses: actions/cache@v2
-        name: Cache plugin dir
-        with:
-          path: ~/.tflint.d/plugins
-          key: tflint-${{ hashFiles('.tflint.hcl') }}
-
-      - uses: terraform-linters/setup-tflint@v1
-        name: Setup tflint
-        with:
-          tflint_version: v0.30.0
-      - name: Show version
-        run: tflint --version
-
-      - name: Check Terraform Manifests
-        run: |
-          terraform init -backend=false -input=false
-          tflint --init
-          tflint -f compact
-        working-directory: ./terraform

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,5 +92,6 @@ COPY --from=assets /home/app/public/ /home/app/public/
 
 EXPOSE 3000
 ENV PATH="/home/app/bin:${PATH}"
+ENV SETTINGS__FFMPEG__PATH="/usr/local/bin/ffmpeg"
 CMD bin/boot_container
 HEALTHCHECK --start-period=60s CMD curl -f http://localhost:3000/

--- a/app/services/security_service.rb
+++ b/app/services/security_service.rb
@@ -22,7 +22,7 @@ class SecurityService
       expiration = Settings.streaming.stream_token_ttl.to_f.minutes.from_now
       case context[:protocol]
       when :stream_hls
-        streaming_url = URI.encode(Addressable::URI.join(Settings.streaming.http_base,uri.path).to_s)
+        streaming_url = URI.encode(Addressable::URI.join(Settings.streaming.http_base,URI.decode(uri.path)).to_s)
         url_signer.signed_url(streaming_url, expires: expiration)
       else
         url


### PR DESCRIPTION
Fixes issue generating poster/thumbnail when the master file has spaces in the filename