### PR TITLE
Address styling and layout issues of Manage dropdowns 

### DIFF
--- a/app/assets/stylesheets/northwestern/components/_layout.scss
+++ b/app/assets/stylesheets/northwestern/components/_layout.scss
@@ -3,14 +3,6 @@ main {
   font-family: $sansRegular;
 }
 
-main .container-md {
-  display: flex;
-
-  @media screen and (max-width: 71.25em) {
-    flex-wrap: wrap;
-  }
-}
-
 .hide-label,
 .hide-text {
   position: absolute;

--- a/app/assets/stylesheets/northwestern/components/_navbar.scss
+++ b/app/assets/stylesheets/northwestern/components/_navbar.scss
@@ -31,7 +31,6 @@
 }
 
 button.navbar-toggler {
-  background: $purple120 !important;
 }
 
 @media screen and (max-width: 71.25em) {
@@ -58,11 +57,28 @@ button.navbar-toggler {
 // custom manage button updates
 
 .manage-btn {
-  @extend .btn-primary;
+  // @extend .btn-primary;
+  color: $purple !important;
+  background: transparent;
+
+  &:hover,
+  &:focus {
+    background: transparent !important;
+    color: $purple120 !important;
+  }
 }
 
-.manage-dropdown-menu {
-  background-color: $purple !important;
+ul.manage-dropdown-menu {
+  background-color: $gray6 !important;
+
+  li {
+    a {
+      color: $purple !important;
+      font-family: $sansRegular;
+      font-size: 16px;
+      padding: 0.5rem 1rem;
+    }
+  }
 }
 
 #header-navbar {

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -33,11 +33,13 @@ http://www.apache.org/licenses/LICENSE-2.0
     </div>
   </div>
   <% else %>
-  <div id="sidebar" class="<%= sidebar_classes %>">
-    <%= render 'search_sidebar' %>
-  </div>
+  <div class="row">
+    <div id="sidebar" class="<%= sidebar_classes %>">
+      <%= render 'search_sidebar' %>
+    </div>
 
-  <div id="content" class="<%= main_content_classes %>">
-    <%= render 'search_results' %>
+    <div id="content" class="<%= main_content_classes %>">
+      <%= render 'search_results' %>
+    </div>
   </div>
 <% end %>


### PR DESCRIPTION
## What does this do?

This addresses two issues related to layout and styling: 

- Ensures wrapping of Manage subpages by removing the a `flex` display
- Adds a bootstrap `row` to wrap content on browse page
- Address contrast issues and colors on manage dropdown
